### PR TITLE
Add varieties and purchase lots tables

### DIFF
--- a/drizzle/0000_superb_boomer.sql
+++ b/drizzle/0000_superb_boomer.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "purchase_lots" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "purchase_lots_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"varietyId" integer NOT NULL,
+	"date" date NOT NULL,
+	"initialWeightKg" numeric(10, 2) NOT NULL,
+	"remainingWeightKg" numeric(10, 2) NOT NULL,
+	"cost" numeric(10, 2) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "users_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"name" varchar(255) NOT NULL,
+	"age" integer NOT NULL,
+	"email" varchar(255) NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "varieties" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "varieties_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"name" varchar(255) NOT NULL,
+	"description" varchar(255)
+);
+--> statement-breakpoint
+ALTER TABLE "purchase_lots" ADD CONSTRAINT "purchase_lots_varietyId_varieties_id_fk" FOREIGN KEY ("varietyId") REFERENCES "public"."varieties"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,191 @@
+{
+  "id": "066a1654-858b-4516-b450-511e1ab36767",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.purchase_lots": {
+      "name": "purchase_lots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "purchase_lots_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "varietyId": {
+          "name": "varietyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialWeightKg": {
+          "name": "initialWeightKg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remainingWeightKg": {
+          "name": "remainingWeightKg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_lots_varietyId_varieties_id_fk": {
+          "name": "purchase_lots_varietyId_varieties_id_fk",
+          "tableFrom": "purchase_lots",
+          "tableTo": "varieties",
+          "columnsFrom": [
+            "varietyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.varieties": {
+      "name": "varieties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "varieties_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1756223636145,
+      "tag": "0000_superb_boomer",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,23 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+import { date, integer, numeric, pgTable, varchar } from "drizzle-orm/pg-core";
 
 export const usersTable = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),
   age: integer().notNull(),
   email: varchar({ length: 255 }).notNull().unique(),
+});
+
+export const varieties = pgTable("varieties", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  description: varchar({ length: 255 }),
+});
+
+export const purchaseLots = pgTable("purchase_lots", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  varietyId: integer().notNull().references(() => varieties.id),
+  date: date().notNull(),
+  initialWeightKg: numeric({ precision: 10, scale: 2 }).notNull(),
+  remainingWeightKg: numeric({ precision: 10, scale: 2 }).notNull(),
+  cost: numeric({ precision: 10, scale: 2 }).notNull(),
 });


### PR DESCRIPTION
## Summary
- add varieties and purchase_lots tables to schema
- generate initial drizzle migration

## Testing
- `npx drizzle-kit generate`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npx drizzle-kit push` *(fails: ECONNREFUSED)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68add83ea0c883308215482b0ef61555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a catalog for product varieties (name and description).
  * Enabled tracking of purchase lots with date, initial/remaining weight, and cost, linked to a variety.
  * Introduced user records with a unique email requirement.

* **Chores**
  * Initialized database schema and migration metadata to support the new entities and relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->