### PR TITLE
feat: add sales and inventory management

### DIFF
--- a/src/app/api/packaged-stock/route.ts
+++ b/src/app/api/packaged-stock/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { packagedStockTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET() {
+  const stock = await db.select().from(packagedStockTable);
+  return NextResponse.json(stock);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const [record] = await db.insert(packagedStockTable).values(body).returning();
+  return NextResponse.json(record);
+}
+
+export async function PUT(req: Request) {
+  const { id, units } = await req.json();
+  await db
+    .update(packagedStockTable)
+    .set({ units })
+    .where(eq(packagedStockTable.id, id));
+  return NextResponse.json({ id, units });
+}
+
+export async function DELETE(req: Request) {
+  const { id } = await req.json();
+  await db.delete(packagedStockTable).where(eq(packagedStockTable.id, id));
+  return NextResponse.json({ id });
+}

--- a/src/app/api/sales/route.ts
+++ b/src/app/api/sales/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import {
+  salesTable,
+  saleItemsTable,
+  packagedStockTable,
+  lotsTable,
+} from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+
+interface SaleItemInput {
+  varietyId: number;
+  size: number;
+  units: number;
+  precioUnitario: number;
+}
+
+export async function GET() {
+  const sales = await db.select().from(salesTable);
+  return NextResponse.json(sales);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const items: SaleItemInput[] = body.items || [];
+  const fecha = body.fecha ? new Date(body.fecha) : undefined;
+  const total = items.reduce(
+    (sum, i) => sum + Number(i.precioUnitario) * Number(i.units),
+    0,
+  );
+  const [sale] = await db
+    .insert(salesTable)
+    .values({ fecha, total: total.toString() })
+    .returning();
+  for (const item of items) {
+    await db
+      .insert(saleItemsTable)
+      .values({
+        saleId: sale.id,
+        varietyId: item.varietyId,
+        size: item.size,
+        units: item.units,
+        precioUnitario: item.precioUnitario.toString(),
+      });
+    const [stock] = await db
+      .select()
+      .from(packagedStockTable)
+      .where(
+        and(
+          eq(packagedStockTable.varietyId, item.varietyId),
+          eq(packagedStockTable.size, item.size),
+        ),
+      )
+      .limit(1);
+    if (stock) {
+      const newUnits = stock.units - item.units;
+      await db
+        .update(packagedStockTable)
+        .set({ units: newUnits })
+        .where(eq(packagedStockTable.id, stock.id));
+      const [lot] = await db
+        .select()
+        .from(lotsTable)
+        .where(eq(lotsTable.id, stock.lotId))
+        .limit(1);
+      if (lot) {
+        const newWeight = Number(lot.remainingWeight) - item.units * item.size;
+        await db
+          .update(lotsTable)
+          .set({ remainingWeight: newWeight.toString() })
+          .where(eq(lotsTable.id, lot.id));
+      }
+    }
+  }
+  return NextResponse.json({ id: sale.id });
+}

--- a/src/app/dashboard/inventario/page.tsx
+++ b/src/app/dashboard/inventario/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface StockItem {
+  id: number;
+  varietyId: number;
+  size: number;
+  units: number;
+}
+
+export default function InventarioPage() {
+  const [stock, setStock] = useState<StockItem[]>([]);
+
+  const load = async () => {
+    const res = await fetch("/api/packaged-stock");
+    const data = await res.json();
+    setStock(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const updateUnits = async (id: number, units: number) => {
+    await fetch("/api/packaged-stock", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, units }),
+    });
+    load();
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {stock.map((s) => (
+        <div key={s.id} className="flex items-center gap-2">
+          <span>
+            {s.varietyId} - {s.size}g
+          </span>
+          <input
+            type="number"
+            defaultValue={s.units}
+            onBlur={(e) => updateUnits(s.id, Number(e.target.value))}
+            className="border p-1 w-20"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/ventas/page.tsx
+++ b/src/app/dashboard/ventas/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+
+export default function VentasPage() {
+  const [form, setForm] = useState({
+    varietyId: "",
+    size: "",
+    units: "",
+    precioUnitario: "",
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch("/api/sales", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          {
+            varietyId: Number(form.varietyId),
+            size: Number(form.size),
+            units: Number(form.units),
+            precioUnitario: Number(form.precioUnitario),
+          },
+        ],
+      }),
+    });
+    setForm({ varietyId: "", size: "", units: "", precioUnitario: "" });
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-2 max-w-xs">
+      <input
+        name="varietyId"
+        value={form.varietyId}
+        onChange={handleChange}
+        placeholder="Variety ID"
+        className="border p-1"
+      />
+      <input
+        name="size"
+        value={form.size}
+        onChange={handleChange}
+        placeholder="Size"
+        className="border p-1"
+      />
+      <input
+        name="units"
+        value={form.units}
+        onChange={handleChange}
+        placeholder="Units"
+        className="border p-1"
+      />
+      <input
+        name="precioUnitario"
+        value={form.precioUnitario}
+        onChange={handleChange}
+        placeholder="Precio Unitario"
+        className="border p-1"
+      />
+      <button type="submit" className="border p-1">
+        Vender
+      </button>
+    </form>
+  );
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,6 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema";
+
+const client = postgres(process.env.DATABASE_URL!);
+export const db = drizzle(client, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,11 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+import {
+  integer,
+  pgTable,
+  varchar,
+  numeric,
+  timestamp,
+  primaryKey,
+} from "drizzle-orm/pg-core";
 
 export const usersTable = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
@@ -6,3 +13,36 @@ export const usersTable = pgTable("users", {
   age: integer().notNull(),
   email: varchar({ length: 255 }).notNull().unique(),
 });
+
+export const lotsTable = pgTable("lots", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  remainingWeight: numeric().notNull(),
+});
+
+export const packagedStockTable = pgTable("packaged_stock", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  varietyId: integer().notNull(),
+  size: integer().notNull(),
+  units: integer().notNull(),
+  lotId: integer().notNull().references(() => lotsTable.id),
+});
+
+export const salesTable = pgTable("sales", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  fecha: timestamp({ mode: "date" }).defaultNow().notNull(),
+  total: numeric().notNull(),
+});
+
+export const saleItemsTable = pgTable(
+  "sale_items",
+  {
+    saleId: integer().notNull().references(() => salesTable.id),
+    varietyId: integer().notNull(),
+    size: integer().notNull(),
+    units: integer().notNull(),
+    precioUnitario: numeric().notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.saleId, table.varietyId, table.size] }),
+  })
+);


### PR DESCRIPTION
## Summary
- define sales and sale item tables and inventory tables
- implement sales API that deducts packaged stock and updates lot weight
- add dashboard pages and API routes to sell and manage inventory

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68add8778bb48330a05f1c67163e4641