### PR TITLE
feat: add dynamic side menu components

### DIFF
--- a/src/components/dynamic-side-menu.stories.tsx
+++ b/src/components/dynamic-side-menu.stories.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { IconHome, IconSettings } from "@tabler/icons-react";
+
+import { DynamicSideMenu } from "./dynamic-side-menu";
+
+/** Ejemplo de uso de `DynamicSideMenu`. */
+export function ExampleDynamicSideMenu() {
+  return (
+    <DynamicSideMenu
+      groups={[
+        {
+          label: "General",
+          items: [
+            { title: "Inicio", url: "/", icon: IconHome },
+            { title: "Configuración", url: "/settings", icon: IconSettings },
+          ],
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/dynamic-side-menu.tsx
+++ b/src/components/dynamic-side-menu.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { type Icon } from "@tabler/icons-react";
+import { DynamicSidebarGroup } from "./dynamic-sidebar-group";
+
+/**
+ * Estructura de un elemento de menú individual.
+ */
+export interface DynamicSideMenuItem {
+  /** Texto visible del elemento. */
+  title: string;
+  /** URL de destino del enlace. */
+  url: string;
+  /** Icono opcional que se mostrará junto al título. */
+  icon?: Icon;
+}
+
+/**
+ * Configuración de un grupo de menú.
+ */
+export interface DynamicSideMenuGroup {
+  /** Etiqueta opcional del grupo. */
+  label?: string;
+  /** Elementos que pertenecen al grupo. */
+  items: DynamicSideMenuItem[];
+}
+
+/**
+ * Props para `DynamicSideMenu`.
+ */
+export interface DynamicSideMenuProps {
+  /** Conjunto de grupos a renderizar en el menú. */
+  groups: DynamicSideMenuGroup[];
+}
+
+/**
+ * Renderiza un menú lateral basado en una configuración dinámica de grupos.
+ */
+export function DynamicSideMenu({ groups }: DynamicSideMenuProps) {
+  return (
+    <>
+      {groups.map((group, index) => (
+        <DynamicSidebarGroup key={group.label ?? index} {...group} />
+      ))}
+    </>
+  );
+}

--- a/src/components/dynamic-sidebar-group.stories.tsx
+++ b/src/components/dynamic-sidebar-group.stories.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { IconHome } from "@tabler/icons-react";
+
+import { DynamicSidebarGroup } from "./dynamic-sidebar-group";
+
+/** Ejemplo de uso de `DynamicSidebarGroup`. */
+export function ExampleSidebarGroup() {
+  return (
+    <DynamicSidebarGroup
+      label="General"
+      items={[
+        { title: "Inicio", url: "/", icon: IconHome },
+      ]}
+    />
+  );
+}

--- a/src/components/dynamic-sidebar-group.tsx
+++ b/src/components/dynamic-sidebar-group.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { type Icon } from "@tabler/icons-react";
+
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+/**
+ * Representa un grupo dentro del menú lateral.
+ * Permite renderizar un conjunto de enlaces bajo una etiqueta opcional.
+ */
+export interface DynamicSidebarGroupProps {
+  /**
+   * Etiqueta del grupo mostrada encima de los elementos.
+   * Si no se proporciona, el grupo se renderiza sin título.
+   */
+  label?: string;
+  /**
+   * Elementos que se mostrarán en el grupo.
+   */
+  items: {
+    /**
+     * Texto visible del elemento.
+     */
+    title: string;
+    /**
+     * URL de destino del enlace.
+     */
+    url: string;
+    /**
+     * Icono opcional que se mostrará junto al título.
+     */
+    icon?: Icon;
+  }[];
+}
+
+/**
+ * Componente que renderiza un grupo de elementos de menú basándose en
+ * la configuración proporcionada.
+ */
+export function DynamicSidebarGroup({ label, items }: DynamicSidebarGroupProps) {
+  return (
+    <SidebarGroup>
+      {label && <SidebarGroupLabel>{label}</SidebarGroupLabel>}
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {items.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton asChild>
+                <a href={item.url}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                </a>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}


### PR DESCRIPTION
## Summary
- implementa `DynamicSideMenu` y `DynamicSidebarGroup` para renderizar menús basados en configuraciones dinámicas
- añade historias de ejemplo para ambos componentes

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae32d41c788330b3c67af91919996c