### PR TITLE
feat: manejar indisponibilidad de la base de datos

### DIFF
--- a/src/app/api/packaged-stock/route.ts
+++ b/src/app/api/packaged-stock/route.ts
@@ -21,6 +21,9 @@ const deleteSchema = z.object({
 });
 
 export async function GET() {
+  if (!db) {
+    return NextResponse.json([]);
+  }
   try {
     const stock = await db.select().from(packagedStockTable);
     return NextResponse.json(stock);
@@ -35,6 +38,12 @@ export async function GET() {
 export async function POST(req: Request) {
   try {
     const body = postSchema.parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
     const [record] = await db
       .insert(packagedStockTable)
       .values(body)
@@ -57,6 +66,12 @@ export async function POST(req: Request) {
 export async function PUT(req: Request) {
   try {
     const { id, units } = putSchema.parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
     await db
       .update(packagedStockTable)
       .set({ units })
@@ -79,6 +94,12 @@ export async function PUT(req: Request) {
 export async function DELETE(req: Request) {
   try {
     const { id } = deleteSchema.parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
     await db
       .delete(packagedStockTable)
       .where(eq(packagedStockTable.id, id));

--- a/src/app/api/sales/route.ts
+++ b/src/app/api/sales/route.ts
@@ -22,6 +22,9 @@ const saleSchema = z.object({
 });
 
 export async function GET() {
+  if (!db) {
+    return NextResponse.json([]);
+  }
   try {
     const sales = await db.select().from(salesTable);
     return NextResponse.json(sales);
@@ -36,6 +39,12 @@ export async function GET() {
 export async function POST(req: Request) {
   try {
     const { items, fecha } = saleSchema.parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
     const parsedFecha = fecha ? new Date(fecha) : undefined;
     const total = items.reduce(
       (sum, i) => sum + Number(i.precioUnitario) * Number(i.units),

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,7 +3,15 @@ import postgres from "postgres";
 import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL;
+let db: PostgresJsDatabase<typeof schema> | null = null;
 
-export const db: PostgresJsDatabase<typeof schema> = connectionString
-  ? drizzle(postgres(connectionString), { schema })
-  : ({} as PostgresJsDatabase<typeof schema>);
+if (connectionString) {
+  try {
+    db = drizzle(postgres(connectionString), { schema });
+  } catch (error) {
+    console.error("Error al inicializar la base de datos:", error);
+  }
+}
+
+export { db };
+

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -13,27 +13,27 @@ export interface DashboardStats {
  * configurada, devuelve valores por defecto para evitar errores en desarrollo.
  */
 export async function getDashboardStats(): Promise<DashboardStats> {
-  if ("select" in db) {
-    const [userCount] = await db
-      .select({ value: sql<number>`count(*)` })
-      .from(usersTable);
-    const [salesCount] = await db
-      .select({ value: sql<number>`count(*)` })
-      .from(salesTable);
-    const [productCount] = await db
-      .select({ value: sql<number>`count(*)` })
-      .from(packagedStockTable);
+  if (!db) {
+    // Datos por defecto en caso de no haber base de datos
     return {
-      summary: userCount?.value ?? 0,
-      sales: salesCount?.value ?? 0,
-      products: productCount?.value ?? 0,
+      summary: 0,
+      sales: 0,
+      products: 0,
     };
   }
 
-  // Datos por defecto en caso de no haber base de datos
+  const [userCount] = await db
+    .select({ value: sql<number>`count(*)` })
+    .from(usersTable);
+  const [salesCount] = await db
+    .select({ value: sql<number>`count(*)` })
+    .from(salesTable);
+  const [productCount] = await db
+    .select({ value: sql<number>`count(*)` })
+    .from(packagedStockTable);
   return {
-    summary: 0,
-    sales: 0,
-    products: 0,
+    summary: userCount?.value ?? 0,
+    sales: salesCount?.value ?? 0,
+    products: productCount?.value ?? 0,
   };
 }


### PR DESCRIPTION
## Resumen
- Manejo de conexión a la base de datos con fallback cuando no hay URL o falla la inicialización.
- Rutas de ventas y stock empaquetado verifican la disponibilidad de la base antes de operar, devolviendo datos simulados o errores 503 según corresponda.

## Pruebas
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae399b65188330834a755f89100355