### PR TITLE
feat: gestión de recursos en dashboard

### DIFF
--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { z, ZodError } from "zod";
+
+interface Promotion {
+  id: number;
+  title: string;
+  discount: number;
+}
+
+let promotions: Promotion[] = [];
+
+const promoSchema = z.object({
+  title: z.string(),
+  discount: z.number(),
+});
+
+export async function GET() {
+  return NextResponse.json(promotions);
+}
+
+export async function POST(req: Request) {
+  try {
+    const data = promoSchema.parse(await req.json());
+    const promotion: Promotion = { id: Date.now(), ...data };
+    promotions.push(promotion);
+    return NextResponse.json(promotion, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "Datos inválidos" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Error al crear promoción" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const { id } = z.object({ id: z.number() }).parse(await req.json());
+    promotions = promotions.filter((p) => p.id !== id);
+    return NextResponse.json({ id });
+  } catch (error) {
+    if (error instanceof ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "Datos inválidos" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Error al eliminar promoción" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { usersTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { z, ZodError } from "zod";
+
+const userSchema = z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().email(),
+});
+
+export async function GET() {
+  if (!db) {
+    return NextResponse.json([]);
+  }
+  try {
+    const users = await db.select().from(usersTable);
+    return NextResponse.json(users);
+  } catch {
+    return NextResponse.json(
+      { error: "Error al obtener usuarios" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const data = userSchema.parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
+    const [user] = await db.insert(usersTable).values(data).returning();
+    return NextResponse.json(user, { status: 201 });
+  } catch (error) {
+    if (error instanceof ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "Datos inválidos" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Error al crear usuario" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const { id } = z.object({ id: z.number() }).parse(await req.json());
+    if (!db) {
+      return NextResponse.json(
+        { error: "Base de datos no disponible" },
+        { status: 503 },
+      );
+    }
+    await db.delete(usersTable).where(eq(usersTable.id, id));
+    return NextResponse.json({ id });
+  } catch (error) {
+    if (error instanceof ZodError || error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "Datos inválidos" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Error al eliminar usuario" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/dashboard/analisis/page.tsx
+++ b/src/app/dashboard/analisis/page.tsx
@@ -1,7 +1,16 @@
-import React from "react";
+import { getDashboardStats } from "@/lib/dashboard";
 
-function AnalyticsPage() {
-  return <div>Análisis</div>;
+export default async function AnalyticsPage() {
+  const stats = await getDashboardStats();
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Análisis</h1>
+      <ul className="space-y-2">
+        <li>Usuarios: {stats.summary}</li>
+        <li>Ventas: {stats.sales}</li>
+        <li>Productos: {stats.products}</li>
+      </ul>
+    </div>
+  );
 }
 
-export default AnalyticsPage;

--- a/src/app/dashboard/clientes/page.tsx
+++ b/src/app/dashboard/clientes/page.tsx
@@ -1,7 +1,100 @@
-import React from "react";
+"use client";
 
-function CustomerPage() {
-  return <div>Clientes</div>;
+import { useEffect, useState } from "react";
+
+interface Cliente {
+  id: number;
+  name: string;
+  age: number;
+  email: string;
 }
 
-export default CustomerPage;
+export default function CustomerPage() {
+  const [clientes, setClientes] = useState<Cliente[]>([]);
+  const [form, setForm] = useState({ name: "", age: "", email: "" });
+
+  const load = async () => {
+    const res = await fetch("/api/users");
+    const data = await res.json();
+    setClientes(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch("/api/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: form.name,
+        age: Number(form.age),
+        email: form.email,
+      }),
+    });
+    setForm({ name: "", age: "", email: "" });
+    load();
+  };
+
+  const remove = async (id: number) => {
+    await fetch("/api/users", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    load();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={submit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Nombre"
+          className="border p-1"
+        />
+        <input
+          name="age"
+          value={form.age}
+          onChange={handleChange}
+          placeholder="Edad"
+          className="border p-1"
+        />
+        <input
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+          className="border p-1"
+        />
+        <button type="submit" className="border p-1">
+          Agregar
+        </button>
+      </form>
+
+      <ul className="flex flex-col gap-1">
+        {clientes.map((c) => (
+          <li key={c.id} className="flex items-center gap-2">
+            <span>
+              {c.name} ({c.email})
+            </span>
+            <button
+              onClick={() => remove(c.id)}
+              className="text-red-600 text-sm"
+            >
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/dashboard/pedidos/page.tsx
+++ b/src/app/dashboard/pedidos/page.tsx
@@ -1,7 +1,38 @@
-import React from "react";
+"use client";
 
-function OrderPage() {
-  return <div>Pedidos</div>;
+import { useEffect, useState } from "react";
+
+interface Sale {
+  id: number;
+  fecha: string | null;
+  total: string;
 }
 
-export default OrderPage;
+export default function OrderPage() {
+  const [sales, setSales] = useState<Sale[]>([]);
+
+  const load = async () => {
+    const res = await fetch("/api/sales");
+    const data = await res.json();
+    setSales(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {sales.map((s) => (
+        <div key={s.id} className="border p-2 rounded">
+          <div>ID: {s.id}</div>
+          <div>
+            Fecha: {s.fecha ? new Date(s.fecha).toLocaleDateString() : "—"}
+          </div>
+          <div>Total: {s.total}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/app/dashboard/productos/page.tsx
+++ b/src/app/dashboard/productos/page.tsx
@@ -1,7 +1,114 @@
-import React from "react";
+"use client";
 
-function ProductPage() {
-  return <div>Productos</div>;
+import { useEffect, useState } from "react";
+
+interface Producto {
+  id: number;
+  varietyId: number;
+  lotId: number;
+  size: number;
+  units: number;
 }
 
-export default ProductPage;
+export default function ProductPage() {
+  const [products, setProducts] = useState<Producto[]>([]);
+  const [form, setForm] = useState({
+    varietyId: "",
+    lotId: "",
+    size: "",
+    units: "",
+  });
+
+  const load = async () => {
+    const res = await fetch("/api/packaged-stock");
+    const data = await res.json();
+    setProducts(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch("/api/packaged-stock", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        varietyId: Number(form.varietyId),
+        lotId: Number(form.lotId),
+        size: Number(form.size),
+        units: Number(form.units),
+      }),
+    });
+    setForm({ varietyId: "", lotId: "", size: "", units: "" });
+    load();
+  };
+
+  const remove = async (id: number) => {
+    await fetch("/api/packaged-stock", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    load();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={submit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          name="varietyId"
+          value={form.varietyId}
+          onChange={handleChange}
+          placeholder="Variedad"
+          className="border p-1"
+        />
+        <input
+          name="lotId"
+          value={form.lotId}
+          onChange={handleChange}
+          placeholder="Lote"
+          className="border p-1"
+        />
+        <input
+          name="size"
+          value={form.size}
+          onChange={handleChange}
+          placeholder="Tamaño (g)"
+          className="border p-1"
+        />
+        <input
+          name="units"
+          value={form.units}
+          onChange={handleChange}
+          placeholder="Unidades"
+          className="border p-1"
+        />
+        <button type="submit" className="border p-1">
+          Agregar
+        </button>
+      </form>
+
+      <ul className="flex flex-col gap-1">
+        {products.map((p) => (
+          <li key={p.id} className="flex items-center gap-2">
+            <span>
+              {p.varietyId} - Lote {p.lotId} - {p.size}g x {p.units}
+            </span>
+            <button
+              onClick={() => remove(p.id)}
+              className="text-red-600 text-sm"
+            >
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/dashboard/promociones/page.tsx
+++ b/src/app/dashboard/promociones/page.tsx
@@ -1,7 +1,90 @@
-import React from "react";
+"use client";
 
-function PromotionPage() {
-  return <div>Promociones</div>;
+import { useEffect, useState } from "react";
+
+interface Promotion {
+  id: number;
+  title: string;
+  discount: number;
 }
 
-export default PromotionPage;
+export default function PromotionPage() {
+  const [promos, setPromos] = useState<Promotion[]>([]);
+  const [form, setForm] = useState({ title: "", discount: "" });
+
+  const load = async () => {
+    const res = await fetch("/api/promotions");
+    const data = await res.json();
+    setPromos(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch("/api/promotions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: form.title,
+        discount: Number(form.discount),
+      }),
+    });
+    setForm({ title: "", discount: "" });
+    load();
+  };
+
+  const remove = async (id: number) => {
+    await fetch("/api/promotions", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    load();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={submit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+          placeholder="Título"
+          className="border p-1"
+        />
+        <input
+          name="discount"
+          value={form.discount}
+          onChange={handleChange}
+          placeholder="Descuento %"
+          className="border p-1"
+        />
+        <button type="submit" className="border p-1">
+          Crear
+        </button>
+      </form>
+      <ul className="flex flex-col gap-1">
+        {promos.map((p) => (
+          <li key={p.id} className="flex items-center gap-2">
+            <span>
+              {p.title} - {p.discount}%
+            </span>
+            <button
+              onClick={() => remove(p.id)}
+              className="text-red-600 text-sm"
+            >
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Resumen
- Añadidos formularios y listados interactivos para clientes, productos, pedidos y promociones en el dashboard.
- Se incorporaron endpoints API para gestionar usuarios y promociones.
- Página de análisis ahora muestra estadísticas generales del sistema.

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3dabee248330be0a706bcad02e76