### PR TITLE
Agregar pruebas básicas para dashboard y API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert";
+import { getDashboardStats } from "../src/lib/dashboard";
+
+// Verifica los valores por defecto cuando no hay base de datos
+test("getDashboardStats devuelve ceros sin base de datos", async () => {
+  const stats = await getDashboardStats();
+  assert.deepEqual(stats, { summary: 0, sales: 0, products: 0 });
+});

--- a/test/main-components.test.ts
+++ b/test/main-components.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert";
+import { DynamicSideMenu } from "../src/components/dynamic-side-menu";
+import { SiteHeader } from "../src/components/site-header";
+import { NavUser } from "../src/components/nav-user";
+
+// Asegura que los componentes principales estén definidos
+
+test("DynamicSideMenu está definido", () => {
+  assert.equal(typeof DynamicSideMenu, "function");
+});
+
+test("SiteHeader está definido", () => {
+  assert.equal(typeof SiteHeader, "function");
+});
+
+test("NavUser está definido", () => {
+  assert.equal(typeof NavUser, "function");
+});

--- a/test/promotions-api.test.ts
+++ b/test/promotions-api.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert";
+import { GET, POST, DELETE } from "../src/app/api/promotions/route";
+
+// Prueba del ciclo completo de promociones
+
+test("POST, GET y DELETE /api/promotions maneja promociones en memoria", async () => {
+  const createReq = new Request("http://localhost/api/promotions", {
+    method: "POST",
+    body: JSON.stringify({ title: "Oferta", discount: 10 }),
+  });
+  const createRes = await POST(createReq);
+  assert.equal(createRes.status, 201);
+  const created = await createRes.json();
+  assert.equal(created.title, "Oferta");
+
+  const listRes = await GET();
+  const list = await listRes.json();
+  assert.equal(list.length, 1);
+
+  const deleteReq = new Request("http://localhost/api/promotions", {
+    method: "DELETE",
+    body: JSON.stringify({ id: created.id }),
+  });
+  const deleteRes = await DELETE(deleteReq);
+  assert.equal(deleteRes.status, 200);
+
+  const finalRes = await GET();
+  const finalList = await finalRes.json();
+  assert.equal(finalList.length, 0);
+});

--- a/test/users-api.test.ts
+++ b/test/users-api.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert";
+import { GET, POST, DELETE } from "../src/app/api/users/route";
+
+// Prueba de obtención de usuarios sin base de datos
+
+test("GET /api/users devuelve array vacío sin base de datos", async () => {
+  const res = await GET();
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.deepEqual(data, []);
+});
+
+// Prueba de creación de usuarios sin base de datos
+
+test("POST /api/users devuelve 503 sin base de datos", async () => {
+  const req = new Request("http://localhost/api/users", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "Ana",
+      age: 30,
+      email: "ana@example.com",
+    }),
+  });
+  const res = await POST(req);
+  assert.equal(res.status, 503);
+  const data = await res.json();
+  assert.ok(data.error);
+});
+
+// Prueba de eliminación de usuarios sin base de datos
+
+test("DELETE /api/users devuelve 503 sin base de datos", async () => {
+  const req = new Request("http://localhost/api/users", {
+    method: "DELETE",
+    body: JSON.stringify({ id: 1 }),
+  });
+  const res = await DELETE(req);
+  assert.equal(res.status, 503);
+  const data = await res.json();
+  assert.ok(data.error);
+});


### PR DESCRIPTION
## Resumen
- Añadir pruebas unitarias para `getDashboardStats`
- Cubrir rutas API de usuarios y promociones
- Verificar componentes principales
- Configurar CI con GitHub Actions para ejecutar pruebas

## Pruebas
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6be74da08330bc9f9bec189ead28